### PR TITLE
[FEAT] : ⚙️ SearchFragment API 호출 제한, 검색 결과 없음 등의 예외 상황 (네트워크 오류 처리는 미완)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/wetube/SearchFragment.kt
+++ b/app/src/main/java/com/example/wetube/SearchFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import android.widget.Toast
 import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -60,12 +61,21 @@ class SearchFragment : Fragment() {
 
         binding.btnSearch.setOnClickListener {
             val searchText = binding.etSearch.text.toString()
-            searchViewModel.getSearchVideosData(searchText)
+            if (searchText.isNotEmpty()) {
+                searchAdapter.items.clear()
+                searchViewModel.getSearchVideosData(searchText,requireContext())
+            } else {
+                Toast.makeText(requireContext(),"검색어를 입력해주세요.",Toast.LENGTH_SHORT).show()
+            }
         }
 
         searchViewModel.searchVideosResult.observe(viewLifecycleOwner) { items ->
-            searchAdapter.items.addAll(items)
-            searchAdapter.notifyDataSetChanged()
+            if (items.isEmpty()) {
+                Toast.makeText(requireContext(),"검색결과가 없습니다.",Toast.LENGTH_SHORT).show()
+            } else {
+                searchAdapter.items.addAll(items)
+                searchAdapter.notifyDataSetChanged()
+            }
         }
 
         binding.ivSearchBack.setOnClickListener {
@@ -76,6 +86,7 @@ class SearchFragment : Fragment() {
             (requireActivity() as MainActivity).setSelectedNavItem(R.id.fragment_home)
         }
     }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null


### PR DESCRIPTION
SearchFragment 에서 searchAdapter.items.clear() 검색 초기화 설정.  65~79줄

빈 검색창을 검색하면 검색어를 입력해 달라는 toast 메시지 출력, 검색 결과가 없으면  검색 결과가 없다는 toast 메세지 출력.

SearchViewModel 29 ~ 42줄 

API호출에 제한이 있으면 Toast 메시지 출력